### PR TITLE
fix: pass i18n config explicitly to serverSideTranslations to fix pro…

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -4,6 +4,7 @@ import { GetStaticProps } from "next";
 import Head from "next/head";
 import { createClient } from "prismicio";
 import { serverSideTranslations } from "next-i18next/pages/serverSideTranslations";
+import i18nConfig from "../../next-i18next.config";
 import { useTranslation } from "next-i18next/pages";
 import { fetchCategories } from "@/services/fetchCategories";
 import { Category } from "@/schema/Category";
@@ -67,7 +68,7 @@ export const getStaticProps: GetStaticProps = async ({
     return {
         props: {
             sortedCategories,
-            ...(await serverSideTranslations(locale, ["common"])),
+            ...(await serverSideTranslations(locale, ["common"], i18nConfig)),
         },
     };
 };

--- a/src/pages/category/[category].tsx
+++ b/src/pages/category/[category].tsx
@@ -7,6 +7,7 @@ import { GetServerSideProps } from "next";
 import Head from "next/head";
 import { createClient } from "prismicio";
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import i18nConfig from '../../../next-i18next.config'
 import { fetchCategories } from "@/services/fetchCategories";
 import { languages } from "@/config/languages";
 import { Category } from "@/schema/Category";
@@ -75,7 +76,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
             postsResponse,
             category,
             sortedCategories,
-            ...(await serverSideTranslations(locale, ['common']))
+            ...(await serverSideTranslations(locale, ['common'], i18nConfig))
         }
     }
 }

--- a/src/pages/category/all.tsx
+++ b/src/pages/category/all.tsx
@@ -9,6 +9,7 @@ import Head from "next/head";
 import { createClient } from "prismicio";
 import { useTranslation } from 'next-i18next/pages';
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import i18nConfig from '../../../next-i18next.config'
 import { fetchCategories } from "@/services/fetchCategories";
 import { languages } from "@/config/languages";
 import { Category } from "@/schema/Category";
@@ -72,7 +73,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         props: {
             postsResponse,
             sortedCategories,
-            ...(await serverSideTranslations(locale, ['common']))
+            ...(await serverSideTranslations(locale, ['common'], i18nConfig))
         }
     }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import { GetStaticProps } from 'next'
 import Head from 'next/head'
 import { createClient } from 'prismicio'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import i18nConfig from '../../next-i18next.config'
 import { useTranslation } from 'next-i18next/pages'
 import { fetchCategories } from '@/services/fetchCategories'
 import { languages } from '@/config/languages'
@@ -74,7 +75,7 @@ export const getStaticProps: GetStaticProps = async ({ previewData, locale }) =>
 		props: {
 			lastFourPosts,
 			sortedCategories,
-			...(await serverSideTranslations(locale, ['common']))
+			...(await serverSideTranslations(locale, ['common'], i18nConfig))
 		}
 	}
 }

--- a/src/pages/login_callback.tsx
+++ b/src/pages/login_callback.tsx
@@ -7,6 +7,7 @@ import { GetStaticProps } from "next"
 import { useSession } from "next-auth/react"
 import { useTranslation } from 'next-i18next/pages'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import i18nConfig from '../../next-i18next.config'
 import Head from "next/head"
 import { useEffect } from "react"
 
@@ -49,7 +50,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
     return {
         props: {
             sortedCategories,
-            ...(await serverSideTranslations(locale, ['common']))
+            ...(await serverSideTranslations(locale, ['common'], i18nConfig))
         }
     }
 }

--- a/src/pages/post/[uid].tsx
+++ b/src/pages/post/[uid].tsx
@@ -6,6 +6,7 @@ import { GetStaticPaths, GetStaticProps } from "next";
 import Head from "next/head";
 import { createClient } from "prismicio";
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import i18nConfig from '../../../next-i18next.config'
 import { fetchCategories } from "@/services/fetchCategories";
 import { Category } from "@/schema/Category";
 import { useLogin } from "@/hooks/useLogin";
@@ -67,16 +68,13 @@ export const getStaticProps: GetStaticProps = async (context) => {
             props: {
                 post,
                 sortedCategories,
-                ...(await serverSideTranslations(locale, ['common']))
+                ...(await serverSideTranslations(locale, ['common'], i18nConfig))
             }
         }
     } catch (error) {
         console.log(error)
         return {
-            redirect: {
-                destination: `/${locale}/404`,
-                permanent: false
-            }
+            notFound: true
         }
     }
 }

--- a/src/pages/user-settings.tsx
+++ b/src/pages/user-settings.tsx
@@ -4,6 +4,7 @@ import { Category } from "@/schema/Category"
 import { fetchCategories } from "@/services/fetchCategories"
 import { GetServerSideProps } from "next"
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import i18nConfig from '../../next-i18next.config'
 import Head from "next/head"
 import { parseCookies } from "nookies"
 import { useTranslation } from 'next-i18next/pages'
@@ -59,7 +60,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
     return {
         props: {
             sortedCategories,
-            ...(await serverSideTranslations(ctx.locale, ['common']))
+            ...(await serverSideTranslations(ctx.locale, ['common'], i18nConfig))
         }
     }
 }


### PR DESCRIPTION
…duction 404s

next-i18next cannot auto-discover the config file in serverless environments (/var/task). Passing the config directly prevents the error from being thrown inside getStaticProps, which was silently redirecting post pages to a non-existent 404 route. Also replaces the incorrect redirect with notFound: true.